### PR TITLE
[midi] prevent note state to go below zero

### DIFF
--- a/src/fat1.cc
+++ b/src/fat1.cc
@@ -111,8 +111,10 @@ parse_midi (Fat1* self,
 				}
 				// no break -- fallthrough, note-on velocity 0
 			case 0x80:
-				self->notes [n % 12] -= 1;
-				return 1;
+				if (notes [n % 12]) {
+					self->notes [n % 12] -= 1;
+					return 1;
+				}
 			default:
 				break;
 		}

--- a/src/fat1.cc
+++ b/src/fat1.cc
@@ -111,7 +111,7 @@ parse_midi (Fat1* self,
 				}
 				// no break -- fallthrough, note-on velocity 0
 			case 0x80:
-				if (notes [n % 12]) {
+				if (self->notes [n % 12]) {
 					self->notes [n % 12] -= 1;
 					return 1;
 				}


### PR DESCRIPTION
When receiving a `note off` as first event (e.g. when fat1 is launched in the middle of a note event), the note's state is set to `-1`, thus breaking the on/off note logic : in this case a single `note on` does no longer properly enable the note since it sets its state to `0`.