### PR TITLE
Add fast mode (reduced latency at cost of delayed correction)

### DIFF
--- a/lv2ttl/fat1_chroma.h
+++ b/lv2ttl/fat1_chroma.h
@@ -10,7 +10,7 @@ static const RtkLv2Description _fat1_chroma = {
 	, 0 // uint32_t dsp_descriptor_id
 	, 0 // uint32_t gui_descriptor_id
 	, "Autotune" // const char *plugin_human_id
-	, (const struct LV2Port[28])
+	, (const struct LV2Port[29])
 	{
 		{ "midiin", MIDI_IN, nan, nan, nan, "MIDI In"},
 		{ "in", AUDIO_IN, nan, nan, nan, "Input"},
@@ -40,16 +40,17 @@ static const RtkLv2Description _fat1_chroma = {
 		{ "bend", CONTROL_OUT, nan, -1.000000, 1.000000, "Pitch Bend"},
 		{ "error", CONTROL_OUT, nan, -1.000000, 1.000000, "Pitch Error"},
 		{ "latency", CONTROL_OUT, nan, 0.000000, 4096.000000, "latency"},
+		{ "fast", CONTROL_IN, 0.000000, 0.000000, 1.000000, "Reduces latency by reading the buffer before the note correction has been computed. This adds some delay before every note correction but can improve the singer's comfort in live or recording situations"},
 	}
-	, 28 // uint32_t nports_total
+	, 29 // uint32_t nports_total
 	, 1 // uint32_t nports_audio_in
 	, 1 // uint32_t nports_audio_out
 	, 1 // uint32_t nports_midi_in
 	, 0 // uint32_t nports_midi_out
 	, 0 // uint32_t nports_atom_in
 	, 0 // uint32_t nports_atom_out
-	, 25 // uint32_t nports_ctrl
-	, 20 // uint32_t nports_ctrl_in
+	, 26 // uint32_t nports_ctrl
+	, 21 // uint32_t nports_ctrl_in
 	, 5 // uint32_t nports_ctrl_out
 	, 8192 // uint32_t min_atom_bufsiz
 	, false // bool send_time_info

--- a/lv2ttl/fat1_micro.h
+++ b/lv2ttl/fat1_micro.h
@@ -10,7 +10,7 @@ static const RtkLv2Description _fat1_micro = {
 	, 0 // uint32_t dsp_descriptor_id
 	, 0 // uint32_t gui_descriptor_id
 	, "Autotune (microtonal)" // const char *plugin_human_id
-	, (const struct LV2Port[40])
+	, (const struct LV2Port[41])
 	{
 		{ "midiin", MIDI_IN, nan, nan, nan, "MIDI In"},
 		{ "in", AUDIO_IN, nan, nan, nan, "Input"},
@@ -52,16 +52,17 @@ static const RtkLv2Description _fat1_micro = {
 		{ "scale09", CONTROL_IN, 0.000000, -1.000000, 1.000000, "Note Tuning (A)"},
 		{ "scale10", CONTROL_IN, 0.000000, -1.000000, 1.000000, "Note Tuning (A#)"},
 		{ "scale11", CONTROL_IN, 0.000000, -1.000000, 1.000000, "Note Tuning (B)"},
+		{ "fast", CONTROL_IN, 0.000000, 0.000000, 1.000000, " Reduces latency by reading the buffer before the note correction has been computed. This adds some delay before every note correction but can improve the singer's comfort in live or recording situations"},
 	}
-	, 40 // uint32_t nports_total
+	, 41 // uint32_t nports_total
 	, 1 // uint32_t nports_audio_in
 	, 1 // uint32_t nports_audio_out
 	, 1 // uint32_t nports_midi_in
 	, 0 // uint32_t nports_midi_out
 	, 0 // uint32_t nports_atom_in
 	, 0 // uint32_t nports_atom_out
-	, 37 // uint32_t nports_ctrl
-	, 32 // uint32_t nports_ctrl_in
+	, 38 // uint32_t nports_ctrl
+	, 33 // uint32_t nports_ctrl_in
 	, 5 // uint32_t nports_ctrl_out
 	, 8192 // uint32_t min_atom_bufsiz
 	, false // bool send_time_info

--- a/src/fat1.cc
+++ b/src/fat1.cc
@@ -223,7 +223,14 @@ run (LV2_Handle instance, uint32_t n_samples)
 {
 	Fat1* self = (Fat1*)instance;
 
-	*self->port [FAT_LTNC] = self->latency;
+	self->retuner->set_fastmode (*self->port [FAT_FAST]);
+
+	if (*self->port [FAT_FAST]) {
+		*self->port [FAT_LTNC] = self->latency / 4;
+	} else {
+		*self->port [FAT_LTNC] = self->latency;
+	}
+
 
 	if (!self->midiin || n_samples == 0) {
 		return;

--- a/src/fat1.h
+++ b/src/fat1.h
@@ -19,5 +19,6 @@ typedef enum {
 	FAT_ERRR,
 	FAT_LTNC,
 	FAT_SCALE, // +12 notes (microtonal only)
-	FAT_LAST = 40
+	FAT_FAST,
+	FAT_LAST = 41
 } PortIndex;

--- a/src/retuner.h
+++ b/src/retuner.h
@@ -72,6 +72,11 @@ public:
         _notescale[i] = i + v;
     }
 
+    void set_fastmode (float v)
+    {
+        _fastmode = (bool) v;
+    }
+
     int get_noteset (void)
     {
         int k;
@@ -130,7 +135,8 @@ private:
 		LV2AT::Resampler _resampler;
 
     float            _notescale[12];
-
+    bool             _fastmode;
+    int              _latcomp;
 };
 
 };


### PR DESCRIPTION
Hi !

This PR adds a mode for reducing the perceived latency by reading the input buffer ahead of time at cost of a slightly delayed correction (that's where the latency goes...).

It's very useful in situations where hearing the beginning of a word in time is more important than having  the note corrected immediately : enabling this in the singer's monitors can help with articulation. 

What do you think ?