### PR TITLE
Prevent segfault on rare noisy occasions

### DIFF
--- a/src/retuner.cc
+++ b/src/retuner.cc
@@ -398,6 +398,13 @@ void Retuner::findcycle (void)
         y = _fftTdata [j];
         z = _fftTdata [j + 1];
         _cycle = j + 0.5f * (x - z) / (z - 2 * y + x - 1e-9f);
+        if (_cycle < 0) {
+            // sometimes the above formula returns -inf
+            // which ends up crashing the process
+            // Cause : x, y, z being floats
+            // -> Could also be fixed by using doubles instead
+            _cycle = 0;
+        }
     }
 }
 


### PR DESCRIPTION
On rare (noisy and breathy) occasions, fat1 crashes because of what seems to be a float precision error that ends up storing a `_cycle` value of `-inf`. Checking if `_cycle` is negative seemed cheaper than turning the problematic variables into doubles (not sure about that) .