### PR TITLE
fix readahead size

### DIFF
--- a/src/retuner.cc
+++ b/src/retuner.cc
@@ -132,9 +132,9 @@ Retuner::Retuner (int fsamp)
 	}
 
 	if (_upsamp) {
-		_readahed = _ipsize / 2 - _frsize * 4;
-	} else {
 		_readahed = _ipsize / 2 - _frsize * 2;
+	} else {
+		_readahed = _ipsize / 2 - _frsize;
 	}
 }
 


### PR DESCRIPTION
In https://github.com/x42/fat1.lv2/pull/11 I overlooked a small mistake because I needed fat1 to work with extreme pitch values (from -24 to +24 semitones), the fast mode latency can actually be reduced a little bit more with this PR.