### PR TITLE
Refactor Fast mode

### DIFF
--- a/src/fat1.cc
+++ b/src/fat1.cc
@@ -301,7 +301,7 @@ run (LV2_Handle instance, uint32_t n_samples)
 	self->retuner->set_fastmode (*self->port[FAT_FAST]);
 
 	if (*self->port[FAT_FAST]) {
-		*self->port[FAT_LTNC] = self->latency / 4;
+		*self->port[FAT_LTNC] = self->latency / 8;
 	} else {
 		*self->port[FAT_LTNC] = self->latency;
 	}

--- a/src/retuner.h
+++ b/src/retuner.h
@@ -140,8 +140,8 @@ private:
 
 	float _notescale[12];
 	bool  _fastmode;
-	bool  _lastfastmode;
-	int   _readahed;
+	int   _readahead;
+	int   _lastreadahead;
 };
 
 }; // namespace LV2AT


### PR DESCRIPTION
- prevent clicks when toggling fast mode if buffer size < fragment size
- report correct latency when fast mode is enabled
- rename "readahed" to "readahead"