### PR TITLE
Extending the pitch range

### DIFF
--- a/gui/fat1.c
+++ b/gui/fat1.c
@@ -276,18 +276,17 @@ static void prepare_faceplates (Fat1UI* ui) {
 	write_text_full(cr,   "1", ui->font[0], xlp-2, ylp,  0, 3, c_dlf);
 	cairo_destroy (cr);
 
-	INIT_DIAL_SF(ui->dial_bg[4], GED_WIDTH + 16, GED_HEIGHT + 28);
-	RESPLABLEL(-.16);
-	write_text_full(cr, "-24", ui->font[0], xlp+7, ylp-1,  0, 1, c_dlf);
+	INIT_DIAL_SF(ui->dial_bg[4], GED_WIDTH + 8, GED_HEIGHT + 20);
 	RESPLABLEL(0.00);
+	write_text_full(cr, "-24", ui->font[0], xlp+2, ylp,  0, 1, c_dlf);
 	RESPLABLEL(.16);
-	write_text_full(cr, "-12", ui->font[0], xlp+2, ylp-2,  0, 1, c_dlf);
 	RESPLABLEL(.33);
 	RESPLABLEL(0.5);
-	write_text_full(cr,  "0", ui->font[0], xlp,   ylp,  0, 2, c_dlf);
 	RESPLABLEL(.66);
+	write_text_full(cr,  "0", ui->font[0], xlp,   ylp,  0, 2, c_dlf);
 	RESPLABLEL(.83);
-	write_text_full(cr, "+12", ui->font[0], xlp-3, ylp-1,  0, 3, c_dlf);
+	RESPLABLEL(1.0);
+	write_text_full(cr, "+12", ui->font[0], xlp-2, ylp,  0, 3, c_dlf);
 	cairo_destroy (cr);
 
 #undef DIALDOTS
@@ -1134,8 +1133,6 @@ static RobWidget* toplevel (Fat1UI* ui, void* const top) {
 	ui->spn_ctrl[1]->displaymode = 3; // use dots
 	ui->spn_ctrl[2]->displaymode = 3;
 	ui->spn_ctrl[3]->displaymode = 3;
-	ui->spn_ctrl[4]->w_width += 8;
-	ui->spn_ctrl[4]->angle_offset = -0.25;
 
 	/* these numerics are meaningful */
 	robtk_dial_annotation_callback (ui->spn_ctrl[0], dial_annotation_hz, ui);

--- a/gui/fat1.c
+++ b/gui/fat1.c
@@ -130,7 +130,7 @@ const struct CtrlRange ctrl_range[] = {
 	{ 0.0, 1.0, 0.5, 0.01,  2, false, "Bias"},
 	{ 0.5, .02, 0.1, 200.,  5, true,  "Filter"},
 	{ 0.0, 1.0, 1.0, 0.01,  2, false, "Corr."},
-	{ -24., 12.0, 0.0, 0.01,  5, false, "Offset"},
+	{ -2., 2.0, 0.0, 0.01,  5, false, "Offset"},
 };
 
 static const char* tooltips[] = {
@@ -278,15 +278,15 @@ static void prepare_faceplates (Fat1UI* ui) {
 
 	INIT_DIAL_SF(ui->dial_bg[4], GED_WIDTH + 8, GED_HEIGHT + 20);
 	RESPLABLEL(0.00);
-	write_text_full(cr, "-24", ui->font[0], xlp+2, ylp,  0, 1, c_dlf);
+	write_text_full(cr, "-2", ui->font[0], xlp+2, ylp,  0, 1, c_dlf);
 	RESPLABLEL(.16);
 	RESPLABLEL(.33);
 	RESPLABLEL(0.5);
-	RESPLABLEL(.66);
 	write_text_full(cr,  "0", ui->font[0], xlp,   ylp,  0, 2, c_dlf);
+	RESPLABLEL(.66);
 	RESPLABLEL(.83);
 	RESPLABLEL(1.0);
-	write_text_full(cr, "+12", ui->font[0], xlp-2, ylp,  0, 3, c_dlf);
+	write_text_full(cr, "+2", ui->font[0], xlp-2, ylp,  0, 3, c_dlf);
 	cairo_destroy (cr);
 
 #undef DIALDOTS

--- a/gui/fat1.c
+++ b/gui/fat1.c
@@ -130,7 +130,7 @@ const struct CtrlRange ctrl_range[] = {
 	{ 0.0, 1.0, 0.5, 0.01,  2, false, "Bias"},
 	{ 0.5, .02, 0.1, 200.,  5, true,  "Filter"},
 	{ 0.0, 1.0, 1.0, 0.01,  2, false, "Corr."},
-	{ -2., 2.0, 0.0, 0.01,  5, false, "Offset"},
+	{ -24., 12.0, 0.0, 0.01,  5, false, "Offset"},
 };
 
 static const char* tooltips[] = {
@@ -278,15 +278,15 @@ static void prepare_faceplates (Fat1UI* ui) {
 
 	INIT_DIAL_SF(ui->dial_bg[4], GED_WIDTH + 8, GED_HEIGHT + 20);
 	RESPLABLEL(0.00);
-	write_text_full(cr, "-2", ui->font[0], xlp+2, ylp,  0, 1, c_dlf);
+	write_text_full(cr, "-24", ui->font[0], xlp+2, ylp,  0, 1, c_dlf);
 	RESPLABLEL(.16);
 	RESPLABLEL(.33);
 	RESPLABLEL(0.5);
-	write_text_full(cr,  "0", ui->font[0], xlp,   ylp,  0, 2, c_dlf);
 	RESPLABLEL(.66);
+	write_text_full(cr,  "0", ui->font[0], xlp,   ylp,  0, 2, c_dlf);
 	RESPLABLEL(.83);
 	RESPLABLEL(1.0);
-	write_text_full(cr, "+2", ui->font[0], xlp-2, ylp,  0, 3, c_dlf);
+	write_text_full(cr, "+12", ui->font[0], xlp-2, ylp,  0, 3, c_dlf);
 	cairo_destroy (cr);
 
 #undef DIALDOTS

--- a/gui/fat1.c
+++ b/gui/fat1.c
@@ -152,7 +152,7 @@ static const char* tooltips[] = {
 		"pitch error gets corrected. Full correction may remove\n"
 		"expression or vibrato.\n</markup>",
 
-	"<markup><b>Offset.</b> Adds an offset in the range of -24/+12\n"
+	"<markup><b>Offset.</b> Adds an offset in the range of +/- two\n"
 		"semitones to the pitch correction. With the Correction\n"
 		"control set to zero the result is a constant pitch change.\n</markup>",
 

--- a/gui/fat1.c
+++ b/gui/fat1.c
@@ -152,7 +152,7 @@ static const char* tooltips[] = {
 		"pitch error gets corrected. Full correction may remove\n"
 		"expression or vibrato.\n</markup>",
 
-	"<markup><b>Offset.</b> Adds an offset in the range of +/- two\n"
+	"<markup><b>Offset.</b> Adds an offset in the range of -24/+12\n"
 		"semitones to the pitch correction. With the Correction\n"
 		"control set to zero the result is a constant pitch change.\n</markup>",
 

--- a/gui/fat1.c
+++ b/gui/fat1.c
@@ -122,6 +122,7 @@ typedef struct {
 
 	bool microtonal;
 	bool scales;
+	bool extended_pitch_range;
 	const char* nfo;
 } Fat1UI;
 
@@ -323,7 +324,10 @@ static void dial_annotation_hz (RobTkDial* d, cairo_t* cr, void* data) {
 static void dial_annotation_val (RobTkDial* d, cairo_t* cr, void* data) {
 	Fat1UI* ui = (Fat1UI*) (data);
 	char txt[16];
-	snprintf (txt, 16, "%+5.0f ct", d->cur * 100.f);
+	if (ui->extended_pitch_range)
+		snprintf (txt, 16, "%+5.0f ct", d->cur * 1200.f);
+	else
+		snprintf (txt, 16, "%+5.0f ct", d->cur * 100.f);
 	display_annotation (ui, d, cr, txt);
 }
 
@@ -1287,14 +1291,21 @@ instantiate (
 	}
 
 	if (0 == strcmp(plugin_uri, FAT1_URI)) {
-		ui->microtonal = false;
-		ui->scales     = false;
+		ui->microtonal 			 = false;
+		ui->scales     			 = false;
+		ui->extended_pitch_range = false;
 	} else if (0 == strcmp(plugin_uri, FAT1_URI "#microtonal")) {
-		ui->microtonal = true;
-		ui->scales     = false;
+		ui->microtonal 			 = true;
+		ui->scales     			 = false;
+		ui->extended_pitch_range = false;
 	} else if (0 == strcmp(plugin_uri, FAT1_URI "#scales")) {
-		ui->microtonal = false;
-		ui->scales     = true;
+		ui->microtonal 			 = false;
+		ui->scales     			 = true;
+		ui->extended_pitch_range = false;
+	} else if (0 == strcmp(plugin_uri, FAT1_URI "#fx")) {
+		ui->microtonal 			 = true;
+		ui->scales     			 = false;
+		ui->extended_pitch_range = true;
 	} else {
 		free (ui);
 		return 0;

--- a/gui/fat1.c
+++ b/gui/fat1.c
@@ -276,17 +276,18 @@ static void prepare_faceplates (Fat1UI* ui) {
 	write_text_full(cr,   "1", ui->font[0], xlp-2, ylp,  0, 3, c_dlf);
 	cairo_destroy (cr);
 
-	INIT_DIAL_SF(ui->dial_bg[4], GED_WIDTH + 8, GED_HEIGHT + 20);
+	INIT_DIAL_SF(ui->dial_bg[4], GED_WIDTH + 16, GED_HEIGHT + 28);
+	RESPLABLEL(-.16);
+	write_text_full(cr, "-24", ui->font[0], xlp+7, ylp-1,  0, 1, c_dlf);
 	RESPLABLEL(0.00);
-	write_text_full(cr, "-24", ui->font[0], xlp+2, ylp,  0, 1, c_dlf);
 	RESPLABLEL(.16);
+	write_text_full(cr, "-12", ui->font[0], xlp+2, ylp-2,  0, 1, c_dlf);
 	RESPLABLEL(.33);
 	RESPLABLEL(0.5);
-	RESPLABLEL(.66);
 	write_text_full(cr,  "0", ui->font[0], xlp,   ylp,  0, 2, c_dlf);
+	RESPLABLEL(.66);
 	RESPLABLEL(.83);
-	RESPLABLEL(1.0);
-	write_text_full(cr, "+12", ui->font[0], xlp-2, ylp,  0, 3, c_dlf);
+	write_text_full(cr, "+12", ui->font[0], xlp-3, ylp-1,  0, 3, c_dlf);
 	cairo_destroy (cr);
 
 #undef DIALDOTS
@@ -1133,6 +1134,8 @@ static RobWidget* toplevel (Fat1UI* ui, void* const top) {
 	ui->spn_ctrl[1]->displaymode = 3; // use dots
 	ui->spn_ctrl[2]->displaymode = 3;
 	ui->spn_ctrl[3]->displaymode = 3;
+	ui->spn_ctrl[4]->w_width += 8;
+	ui->spn_ctrl[4]->angle_offset = -0.25;
 
 	/* these numerics are meaningful */
 	robtk_dial_annotation_callback (ui->spn_ctrl[0], dial_annotation_hz, ui);

--- a/lv2ttl/manifest.ttl.in
+++ b/lv2ttl/manifest.ttl.in
@@ -22,3 +22,8 @@
 	a lv2:Plugin ;
 	lv2:binary <fat1@LIB_EXT@> ;
 	rdfs:seeAlso <fat1.ttl> .
+
+<http://gareus.org/oss/lv2/fat1#fx>
+	a lv2:Plugin ;
+	lv2:binary <fat1@LIB_EXT@> ;
+	rdfs:seeAlso <fat1.ttl> .

--- a/src/fat1.cc
+++ b/src/fat1.cc
@@ -195,7 +195,7 @@ instantiate (const LV2_Descriptor*     descriptor,
 	} else if (0 == strcmp (descriptor->URI, FAT1_URI "#microtonal")) {
 		self->microtonal		   = true;
 		self->scales     		   = false;
-		self->extended_pitch_range = 1;
+		self->extenteed_pitch_range	   = false;
 	} else if (0 == strcmp (descriptor->URI, FAT1_URI "#scales")) {
 		self->microtonal		   = false;
 		self->scales     		   = true;

--- a/src/fat1.cc
+++ b/src/fat1.cc
@@ -301,10 +301,14 @@ run (LV2_Handle instance, uint32_t n_samples)
 	self->retuner->set_fastmode (*self->port[FAT_FAST]);
 
 	if (*self->port[FAT_FAST]) {
-		/* add 32 samples for resampler's latency */
-		*self->port[FAT_LTNC] = self->retuner->upsample () ? 32 : 0 + self->latency / 8;
+		*self->port[FAT_LTNC] = self->latency / 8;
 	} else {
-		*self->port[FAT_LTNC] = self->retuner->upsample () ? 32 : 0 + self->latency;
+		*self->port[FAT_LTNC] = self->latency;
+	}
+
+	if (self->retuner->upsample ()) {
+		/* add 32 samples for resampler's latency */
+		*self->port[FAT_LTNC] += 32;
 	}
 
 	if (!self->midiin || n_samples == 0) {

--- a/src/fat1.cc
+++ b/src/fat1.cc
@@ -195,7 +195,7 @@ instantiate (const LV2_Descriptor*     descriptor,
 	} else if (0 == strcmp (descriptor->URI, FAT1_URI "#microtonal")) {
 		self->microtonal		   = true;
 		self->scales     		   = false;
-		self->extenteed_pitch_range	   = false;
+		self->extended_pitch_range = false;
 	} else if (0 == strcmp (descriptor->URI, FAT1_URI "#scales")) {
 		self->microtonal		   = false;
 		self->scales     		   = true;

--- a/src/retuner.cc
+++ b/src/retuner.cc
@@ -37,6 +37,8 @@ Retuner::Retuner (int fsamp)
     , _fastmode (false)
     , _readahead (0)
     , _lastreadahead (0)
+    , _voiced (false)
+    , _lastvoiced (false)
 {
 	int   i, h;
 	float t, x, y;
@@ -289,6 +291,7 @@ Retuner::process (int nfram, float const* inp, float* out)
 					_cycle = cycle;
 					_count = 0;
 					finderror ();
+					_voiced = true;
 				} else if (++_count > 5) {
 					// If the pitch estimate fails, the current
 					// ratio is kept for 5 fragments. After that
@@ -297,6 +300,7 @@ Retuner::process (int nfram, float const* inp, float* out)
 					_count = 5;
 					_cycle = _frsize;
 					_error = 0;
+					_voiced = false;
 				} else if (_count == 2) {
 					// Bias is removed after two unvoiced fragments.
 					_lastnote = -1;
@@ -338,7 +342,7 @@ Retuner::process (int nfram, float const* inp, float* out)
             // aim to make it stay near 0 while preserving coherence in the signal
 			ph = ph / _frsize - 8;
 
-			if (_cycle == _frsize && _error == 0 && ph != 0.0f) {
+			if (!_voiced && _lastvoiced) {
 				// If signal is unvoiced, reset playhead position and crossfade
 				// to avoid jitter and get a consistent output latency
 				_xfade = true;
@@ -374,6 +378,9 @@ Retuner::process (int nfram, float const* inp, float* out)
 				_readahead = _ipsize * 7 / 16;
 			else
 				_readahead = 0;
+				
+			_lastvoiced = _voiced;
+
 		}
 	}
 

--- a/src/retuner.cc
+++ b/src/retuner.cc
@@ -365,8 +365,12 @@ Retuner::process (int nfram, float const* inp, float* out)
 			_lastreadahead = _readahead;
 
 			if (_fastmode && _ratio < 1.5)
-				// Bypass fast mode when pitch ratio is high to avoid reading
-				// outside the input buffer limits
+				// Bypass fast mode when pitch ratio is high.
+				// In fast mode, the playhead is moved as close as possible behind
+				// the writehead (1/16th of the input buffer instead of 1/2).
+				// Since the playhead may be up to 0.5/16th early (see "ph > 0.5f")
+				// before a jump occurs, playing above 1.5x speed may end up with
+				// the playhead going beyond the writehead before the next jump check.
 				_readahead = _ipsize * 7 / 16;
 			else
 				_readahead = 0;

--- a/src/retuner.cc
+++ b/src/retuner.cc
@@ -150,7 +150,7 @@ int
 Retuner::process (int nfram, float const* inp, float* out)
 {
 	int   i, ii, k, fi;
-	float ph, dp, r1, r2, dr, u1, u2, v;
+	float ph, dp, r1, r2, dr, dr2, u1, u2, v;
 
 	// Pitch shifting is done by resampling the input at the
 	// required ratio, and eventually jumping forward or back
@@ -318,6 +318,12 @@ Retuner::process (int nfram, float const* inp, float* out)
 			// the circular input buffer limits it must be at
 			// least one fragment size.
 			dr = _cycle * (int)(ceilf (_frsize / _cycle));
+
+			// If possible, use a jump size that takes the
+			// playback rate (_ratio) into account
+			dr2 = _cycle * (int)(ceilf (_ratio * _frsize / _cycle));
+			if (dr2 >= _frsize) dr = dr2;
+
 			dp = dr / _frsize;
 			ph = r1 - _ipindex;
 			if (ph < 0)
@@ -327,11 +333,7 @@ Retuner::process (int nfram, float const* inp, float* out)
 				dr *= 2;
 			}
 	
-			if (_ratio < .75)
-				ph = ph / _frsize - 8;
-			else
-				ph = ph / _frsize + 2 * _ratio - 10;
-
+			ph = ph / _frsize - 8;
 			if (ph > 0.5f) {
 				// Jump back by 'dr' frames and crossfade.
 				_xfade = true;

--- a/src/retuner.cc
+++ b/src/retuner.cc
@@ -326,7 +326,12 @@ Retuner::process (int nfram, float const* inp, float* out)
 				ph /= 2;
 				dr *= 2;
 			}
-			ph = ph / _frsize + 2 * _ratio - 10;
+	
+			if (_ratio < .75)
+				ph = ph / _frsize - 8;
+			else
+				ph = ph / _frsize + 2 * _ratio - 10;
+
 			if (ph > 0.5f) {
 				// Jump back by 'dr' frames and crossfade.
 				_xfade = true;

--- a/src/retuner.cc
+++ b/src/retuner.cc
@@ -354,7 +354,9 @@ Retuner::process (int nfram, float const* inp, float* out)
 			// and the pitch analysis. This is useful in live situation.
 			_lastreadahead = _readahead;
 
-			if (_fastmode)
+			if (_fastmode && _ratio < 1.5)
+				// Bypass fast mode when pitch ratio is high to avoid reading
+				// outside the input buffer limits
 				_readahead = _ipsize * 7 / 16;
 			else
 				_readahead = 0;

--- a/src/retuner.cc
+++ b/src/retuner.cc
@@ -339,7 +339,7 @@ Retuner::process (int nfram, float const* inp, float* out)
 			ph = ph / _frsize - 8;
 
 			if (_cycle == _frsize && _error == 0 && ph != 0.0f) {
-				// If signal is unvoiced, reset playhead position and cro
+				// If signal is unvoiced, reset playhead position and crossfade
 				// to avoid jitter and get a consistent output latency
 				_xfade = true;
 				r2 = _ipindex - _ipsize / 2;

--- a/src/retuner.cc
+++ b/src/retuner.cc
@@ -305,6 +305,16 @@ Retuner::process (int nfram, float const* inp, float* out)
 				_ratio = powf (2.0f, _corroffs / 12.0f - _error * _corrgain);
 			}
 
+			// Fast mode allows outputting the signal before the pitch has been computed,
+			// resulting in a lower latency at the cost of a small delay between the correction
+			// and the pitch analysis. This is useful in live situation.
+			_lastreadahead = _readahead;
+
+			if (_fastmode)
+				_readahead = _ipsize * 7 / 16;
+			else
+				_readahead = 0;
+
 			// If the previous fragment was crossfading,
 			// the end of the new fragment that was faded
 			// in becomes the current read position.
@@ -328,6 +338,9 @@ Retuner::process (int nfram, float const* inp, float* out)
 			ph = r1 - _ipindex;
 			if (ph < 0)
 				ph += _ipsize;
+			ph += _readahead;
+			if (ph > _ipsize)
+				ph -= _ipsize;
 			if (_upsamp) {
 				ph /= 2;
 				dr *= 2;
@@ -359,21 +372,6 @@ Retuner::process (int nfram, float const* inp, float* out)
 			if (r2 < 0)
 				r2 += _ipsize;
 
-			// Fast mode allows outputting the signal before the pitch has been computed,
-			// resulting in a lower latency at the cost of a small delay between the correction
-			// and the pitch analysis. This is useful in live situation.
-			_lastreadahead = _readahead;
-
-			if (_fastmode && _ratio < 1.5)
-				// Bypass fast mode when pitch ratio is high.
-				// In fast mode, the playhead is moved as close as possible behind
-				// the writehead (1/16th of the input buffer instead of 1/2).
-				// Since the playhead may be up to 0.5/16th early (see "ph > 0.5f")
-				// before a jump occurs, playing above 1.5x speed may end up with
-				// the playhead going beyond the writehead before the next jump check.
-				_readahead = _ipsize * 7 / 16;
-			else
-				_readahead = 0;
 		}
 	}
 

--- a/src/retuner.h
+++ b/src/retuner.h
@@ -148,6 +148,9 @@ private:
 	bool  _fastmode;
 	int   _readahead;
 	int   _lastreadahead;
+
+	bool _voiced;
+	bool _lastvoiced;
 };
 
 }; // namespace LV2AT


### PR DESCRIPTION
Besides the obvious, this PR also reduces the latency jitter (caused by the granulation) by resetting the playhead's position when the signal is considered unvoiced. It also fixes the resampler latency addition (f31aaeb2d83a1a47adf3fe41bf26923420be2121) which lacked a pair of parenthesis.